### PR TITLE
[SGP-13253] Make rate limiting on login case-insensitive

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -464,7 +464,7 @@ class DefaultAccountAdapter(object):
 
     def _get_login_attempts_cache_key(self, request, **credentials):
         site = get_current_site(request)
-        login = credentials.get('email', credentials.get('username', ''))
+        login = credentials.get('email', credentials.get('username', '')).upper()
         login_key = hashlib.sha256(login.encode('utf8')).hexdigest()
         return 'allauth/login_attempts@{site_id}:{login}'.format(
             site_id=site.pk,

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -536,6 +536,44 @@ class AccountTests(TestCase):
                 else
                 'The username and/or password you specified are not correct.')
 
+
+    @override_settings(
+        ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod
+        .OPTIONAL,
+        ACCOUNT_LOGIN_ATTEMPTS_LIMIT=3)
+    def test_login_failed_attempts_exceeded_with_casing(self):
+        user = get_user_model().objects.create(username='ronald')
+        user.set_password('doe')
+        user.save()
+        EmailAddress.objects.create(user=user,
+                                    email="ronald@example.com",
+                                    primary=True,
+                                    verified=False)
+        for i in range(4):
+            is_locked = (i >= 3)
+            resp = self.client.post(
+                reverse('account_login'),
+                {'login': 'ronald@example.com',
+                 'password': 'wrong'})
+            self.assertFormError(
+                resp,
+                'form',
+                None,
+                'Too many failed login attempts. Try again later.'
+                if is_locked
+                else
+                'The username and/or password you specified are not correct.')
+
+        resp = self.client.post(
+            reverse('account_login'),
+            {'login': 'RoNaLd@example.com',
+             'password': 'wrong'})
+        self.assertFormError(
+            resp,
+            'form',
+            None,
+            'Too many failed login attempts. Try again later.')
+
     def test_login_unverified_account_mandatory(self):
         """Tests login behavior when email verification is mandatory."""
         user = get_user_model().objects.create(username='john')


### PR DESCRIPTION
The cache key needs to always be in a consistent case for rate limiting. Otherwise, it's possible to bypass the rate limiter by changing the casing of part or all of the email address passed to the login form.