### PR TITLE
[SGP-13253] Fix rate limiting bypass via changed casing

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -459,7 +459,7 @@ class DefaultAccountAdapter(object):
 
     def _get_login_attempts_cache_key(self, request, **credentials):
         site = get_current_site(request)
-        login = credentials.get('email', credentials.get('username', ''))
+        login = credentials.get('email', credentials.get('username', '')).lower()
         login_key = hashlib.sha256(login.encode('utf8')).hexdigest()
         return 'allauth/login_attempts@{site_id}:{login}'.format(
             site_id=site.pk,

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -523,7 +523,7 @@ class AccountTests(TestCase):
             is_locked = (i >= 3)
             resp = self.client.post(
                 reverse('account_login'),
-                {'login': 'john',
+                {'login': ['john', 'John', 'JOHN', 'JOhn', 'joHN'][i],
                  'password': (
                      'doe' if is_valid_attempt
                      else 'wrong')})


### PR DESCRIPTION
To minimize how much our branch diverges, this is a backport of the fix for rate limiting which stops users from bypassing limits by changing the casing of their logins. See this commit for source: https://github.com/pennersr/django-allauth/commit/2fa7038a53e77dad504624584d2a533d08a3e7d1