### PR TITLE
[SGP-13178] evidence that I was fixing in the wrong place

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -258,7 +258,7 @@ class SocialLogin(object):
         assert not self.is_existing
         try:
             a = SocialAccount.objects.get(provider=self.account.provider,
-                                          uid=self.account.uid)
+                                          uid__exact=self.account.uid)
             # Update account
             a.extra_data = self.account.extra_data
             self.account = a


### PR DESCRIPTION
NOTE: All `allauth` tests run against in-memory sqlite3.

See last commit. Hit a brick wall here. Only posting it for reviewers benefit.

Final result:

```
======================================================================
FAIL: test_lookup_is_case_sensitive (allauth.socialaccount.tests.SocialLoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/russell/src/bevy/django-allauth/allauth/socialaccount/tests.py", line 726, in test_lookup_is_case_sensitive
    self.assertIsNone(sociallogin.account.pk)
AssertionError: 1 is not None
```