### PR TITLE
feat(oauth2): Add support for PKCE

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,13 @@
+0.51.0 (unreleased)
+*******************
+
+Note worthy changes
+-------------------
+
+- Introduced a new provider setting ``OAUTH_PKCE_ENABLED`` that enables the
+  PKCE-enhanced Authorization Code Flow for OAuth 2.0 providers.
+
+
 0.50.0 (2022-03-25)
 *******************
 

--- a/allauth/socialaccount/providers/apple/client.py
+++ b/allauth/socialaccount/providers/apple/client.py
@@ -58,7 +58,7 @@ class AppleOAuth2Client(OAuth2Client):
         """We support multiple client_ids, but use the first one for api calls"""
         return self.consumer_key.split(",")[0]
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, pkce_code_verifier=None):
         url = self.access_token_url
         client_secret = self.generate_client_secret()
         data = {
@@ -68,6 +68,8 @@ class AppleOAuth2Client(OAuth2Client):
             "redirect_uri": self.callback_url,
             "client_secret": client_secret,
         }
+        if pkce_code_verifier:
+            data["code_verifier"] = pkce_code_verifier
         self._strip_empty_keys(data)
         resp = requests.request(
             self.access_token_method, url, data=data, headers=self.headers

--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -122,7 +122,10 @@ class AppleOAuth2Adapter(OAuth2Adapter):
 
         # Exchange `code`
         code = get_request_param(request, "code")
-        access_token_data = client.get_access_token(code)
+        pkce_code_verifier = request.session.pop("pkce_code_verifier", None)
+        access_token_data = client.get_access_token(
+            code, pkce_code_verifier=pkce_code_verifier
+        )
 
         return {
             **access_token_data,

--- a/allauth/socialaccount/providers/feishu/client.py
+++ b/allauth/socialaccount/providers/feishu/client.py
@@ -50,7 +50,7 @@ class FeishuOAuth2Client(OAuth2Client):
             raise OAuth2Error("Error retrieving app access token: %s" % resp.content)
         return access_token["app_access_token"]
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, pkce_code_verifier=None):
         data = {
             "grant_type": "authorization_code",
             "code": code,
@@ -62,6 +62,8 @@ class FeishuOAuth2Client(OAuth2Client):
         if self.access_token_method == "GET":
             params = data
             data = None
+        if data and pkce_code_verifier:
+            data["code_verifier"] = pkce_code_verifier
         # TODO: Proper exception handling
         resp = requests.request(
             self.access_token_method,

--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -45,7 +45,7 @@ class OAuth2Client(object):
         params.update(extra_params)
         return "%s?%s" % (authorization_url, urlencode(params))
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, pkce_code_verifier=None):
         data = {
             "redirect_uri": self.callback_url,
             "grant_type": "authorization_code",
@@ -67,6 +67,8 @@ class OAuth2Client(object):
         if self.access_token_method == "GET":
             params = data
             data = None
+        if data and pkce_code_verifier:
+            data["code_verifier"] = pkce_code_verifier
         # TODO: Proper exception handling
         resp = requests.request(
             self.access_token_method,

--- a/allauth/socialaccount/providers/oauth2/provider.py
+++ b/allauth/socialaccount/providers/oauth2/provider.py
@@ -5,13 +5,24 @@ from django.utils.http import urlencode
 
 from allauth.socialaccount.providers.base import Provider
 
+from .utils import generate_code_challenge
+
 
 class OAuth2Provider(Provider):
+    pkce_enabled_default = False
+
     def get_login_url(self, request, **kwargs):
         url = reverse(self.id + "_login")
         if kwargs:
             url = url + "?" + urlencode(kwargs)
         return url
+
+    def get_pkce_params(self):
+        settings = self.get_settings()
+        if settings.get("OAUTH_PKCE_ENABLED", self.pkce_enabled_default):
+            pkce_code_params = generate_code_challenge()
+            return pkce_code_params
+        return {}
 
     def get_auth_params(self, request, action):
         settings = self.get_settings()

--- a/allauth/socialaccount/providers/oauth2/utils.py
+++ b/allauth/socialaccount/providers/oauth2/utils.py
@@ -1,0 +1,30 @@
+import base64
+import hashlib
+import random
+
+
+try:
+    from secrets import token_urlsafe
+except ImportError:
+    # token_urlsafe polyfill for Python < 3.6
+    import os
+
+    def token_urlsafe(nbytes=None):
+        if nbytes is None:
+            nbytes = 32
+        tok = os.urandom(nbytes)
+        return base64.urlsafe_b64encode(tok).rstrip(b"=").decode("ascii")
+
+
+def generate_code_challenge():
+    # minimum length of 43 characters, maximum length of 128 characters
+    nbytes = random.randint(43, 128)
+    code_verifier = token_urlsafe(nbytes)
+    hashed_verifier = hashlib.sha256(code_verifier.encode("ascii"))
+    code_challenge = base64.urlsafe_b64encode(hashed_verifier.digest())
+    code_challenge_without_padding = code_challenge.rstrip(b"=")
+    return {
+        "code_verifier": code_verifier,
+        "code_challenge_method": "S256",
+        "code_challenge": code_challenge_without_padding,
+    }

--- a/allauth/socialaccount/providers/untappd/client.py
+++ b/allauth/socialaccount/providers/untappd/client.py
@@ -16,7 +16,7 @@ class UntappdOAuth2Client(OAuth2Client):
         * nests access_token inside an extra 'response' object
     """
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, pkce_code_verifier=None):
         data = {
             "client_id": self.consumer_key,
             "redirect_url": self.callback_url,
@@ -31,6 +31,8 @@ class UntappdOAuth2Client(OAuth2Client):
         if self.access_token_method == "GET":
             params = data
             data = None
+        if data and pkce_code_verifier:
+            data["code_verifier"] = pkce_code_verifier
         # Allow custom User Agent to comply with Untappd API
         settings = app_settings.PROVIDERS.get(UntappdProvider.id, {})
         headers = {"User-Agent": settings.get("USER_AGENT", "django-allauth")}

--- a/allauth/socialaccount/providers/weixin/client.py
+++ b/allauth/socialaccount/providers/weixin/client.py
@@ -25,7 +25,7 @@ class WeixinOAuth2Client(OAuth2Client):
             sorted_params[param] = params[param]
         return "%s?%s" % (authorization_url, urlencode(sorted_params))
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, pkce_code_verifier=None):
         data = {
             "appid": self.consumer_key,
             "redirect_uri": self.callback_url,
@@ -40,6 +40,8 @@ class WeixinOAuth2Client(OAuth2Client):
         if self.access_token_method == "GET":
             params = data
             data = None
+        if data and pkce_code_verifier:
+            data["code_verifier"] = pkce_code_verifier
         # TODO: Proper exception handling
         resp = requests.request(self.access_token_method, url, params=params, data=data)
         access_token = None

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -1,5 +1,8 @@
+import base64
+import hashlib
 import json
 import random
+import requests
 import warnings
 from urllib.parse import parse_qs, urlparse
 
@@ -165,6 +168,36 @@ class OAuth2TestsMixin(object):
         self.provider = providers.registry.by_id(self.provider_id)
         self.app = setup_app(self.provider)
 
+    def test_provider_has_no_pkce_params(self):
+        provider_settings = app_settings.PROVIDERS.get(self.provider_id, {})
+        provider_settings_with_pkce_set = provider_settings.copy()
+        provider_settings_with_pkce_set["OAUTH_PKCE_ENABLED"] = False
+
+        with self.settings(
+            SOCIALACCOUNT_PROVIDERS={self.provider_id: provider_settings_with_pkce_set}
+        ):
+            self.assertEqual(self.provider.get_pkce_params(), {})
+
+    def test_provider_has_pkce_params(self):
+        provider_settings = app_settings.PROVIDERS.get(self.provider_id, {})
+        provider_settings_with_pkce_set = provider_settings.copy()
+        provider_settings_with_pkce_set["OAUTH_PKCE_ENABLED"] = True
+
+        with self.settings(
+            SOCIALACCOUNT_PROVIDERS={self.provider_id: provider_settings_with_pkce_set}
+        ):
+            pkce_params = self.provider.get_pkce_params()
+            self.assertEqual(
+                set(pkce_params.keys()),
+                {"code_challenge", "code_challenge_method", "code_verifier"},
+            )
+            hashed_verifier = hashlib.sha256(
+                pkce_params["code_verifier"].encode("ascii")
+            )
+            code_challenge = base64.urlsafe_b64encode(hashed_verifier.digest())
+            code_challenge_without_padding = code_challenge.rstrip(b"=")
+            assert pkce_params["code_challenge"] == code_challenge_without_padding
+
     @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=False)
     def test_login(self):
         resp_mock = self.get_mocked_response()
@@ -175,6 +208,50 @@ class OAuth2TestsMixin(object):
             resp_mock,
         )
         self.assertRedirects(resp, reverse("socialaccount_signup"))
+
+    @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=False)
+    def test_login_with_pkce_disabled(self):
+        provider_settings = app_settings.PROVIDERS.get(self.provider_id, {})
+        provider_settings_with_pkce_disabled = provider_settings.copy()
+        provider_settings_with_pkce_disabled["OAUTH_PKCE_ENABLED"] = False
+
+        with self.settings(
+            SOCIALACCOUNT_PROVIDERS={
+                self.provider_id: provider_settings_with_pkce_disabled
+            }
+        ):
+            resp_mock = self.get_mocked_response()
+            if not resp_mock:
+                warnings.warn(
+                    "Cannot test provider %s, no oauth mock" % self.provider.id
+                )
+                return
+            resp = self.login(
+                resp_mock,
+            )
+            self.assertRedirects(resp, reverse("socialaccount_signup"))
+
+    @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=False)
+    def test_login_with_pkce_enabled(self):
+        provider_settings = app_settings.PROVIDERS.get(self.provider_id, {})
+        provider_settings_with_pkce_enabled = provider_settings.copy()
+        provider_settings_with_pkce_enabled["OAUTH_PKCE_ENABLED"] = True
+        with self.settings(
+            SOCIALACCOUNT_PROVIDERS={
+                self.provider_id: provider_settings_with_pkce_enabled
+            }
+        ):
+            resp_mock = self.get_mocked_response()
+            if not resp_mock:
+                warnings.warn(
+                    "Cannot test provider %s, no oauth mock" % self.provider.id
+                )
+                return
+
+            resp = self.login(
+                resp_mock,
+            )
+            self.assertRedirects(resp, reverse("socialaccount_signup"))
 
     def test_account_tokens(self, multiple_login=False):
         if not app_settings.STORE_TOKENS:
@@ -229,13 +306,26 @@ class OAuth2TestsMixin(object):
             + "?"
             + urlencode(dict(process=process))
         )
+
         p = urlparse(resp["location"])
         q = parse_qs(p.query)
+
+        pkce_enabled = app_settings.PROVIDERS.get(self.provider_id, {}).get(
+            "OAUTH_PKCE_ENABLED", False
+        )
+
+        self.assertEqual("code_challenge" in q, pkce_enabled)
+        self.assertEqual("code_challenge_method" in q, pkce_enabled)
+        if pkce_enabled:
+            code_challenge = q["code_challenge"][0]
+            self.assertEqual(q["code_challenge_method"][0], "S256")
+
         complete_url = reverse(self.provider.id + "_callback")
         self.assertGreater(q["redirect_uri"][0].find(complete_url), 0)
         response_json = self.get_login_response_json(
             with_refresh_token=with_refresh_token
         )
+
         if isinstance(resp_mock, list):
             resp_mocks = resp_mock
         else:
@@ -246,6 +336,30 @@ class OAuth2TestsMixin(object):
             *resp_mocks,
         ):
             resp = self.client.get(complete_url, self.get_complete_parameters(q))
+
+            # Find the access token POST request, and assert that it contains
+            # the correct code_verifier if and only if PKCE is enabled
+            request_calls = requests.request.call_args_list
+            for args, kwargs in request_calls:
+                data = kwargs.get("data", {})
+                if (
+                    args[0] == "POST"
+                    and isinstance(data, dict)
+                    and data.get("redirect_uri", "").endswith(complete_url)
+                ):
+                    self.assertEqual("code_verifier" in data, pkce_enabled)
+
+                    if pkce_enabled:
+                        hashed_code_verifier = hashlib.sha256(
+                            data["code_verifier"].encode("ascii")
+                        )
+                        expected_code_challenge = (
+                            base64.urlsafe_b64encode(hashed_code_verifier.digest())
+                            .rstrip(b"=")
+                            .decode()
+                        )
+                        self.assertEqual(code_challenge, expected_code_challenge)
+
         return resp
 
     def get_complete_parameters(self, q):

--- a/allauth/tests.py
+++ b/allauth/tests.py
@@ -58,7 +58,7 @@ class mocked_response:
                     return self.responses.pop(0)
                 return f(*args, **kwargs)
 
-            return new_f
+            return Mock(side_effect=new_f)
 
         requests.get = mockable_request(requests.get)
         requests.post = mockable_request(requests.post)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -188,6 +188,7 @@ You'll need to specify the base URL for your Auth0 domain:
     SOCIALACCOUNT_PROVIDERS = {
         'auth0': {
             'AUTH0_URL': 'https://your.auth0domain.auth0.com',
+            'OAUTH_PKCE_ENABLED': True,
         }
     }
 
@@ -999,7 +1000,8 @@ Optionally, you can specify the scope to use as follows:
             ],
             'AUTH_PARAMS': {
                 'access_type': 'online',
-            }
+            },
+            'OAUTH_PKCE_ENABLED': True,
         }
     }
 
@@ -1397,6 +1399,7 @@ Okta
     SOCIALACCOUNT_PROVIDERS = {
         'okta': {
             'OKTA_BASE_URL': 'example.okta.com',
+            'OAUTH_PKCE_ENABLED': True,
         }
     }
 


### PR DESCRIPTION
Add PKCE to OAuth and OAuth2 providers.

This PR supersedes #8, which is based off v0.44.0.

# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
