### PR TITLE
[SGP-29166] change key in common fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
         django-version: ['main', '2.0', '2.1', '2.2', '3.0', '3.1', '3.2', '4.0']
         exclude:
           - python-version: '3.8'
@@ -25,13 +25,9 @@ jobs:
           - python-version: '3.9'
             django-version: '2.1'
 
-          - python-version: '3.6'
-            django-version: '4.0'
           - python-version: '3.7'
             django-version: '4.0'
 
-          - python-version: '3.6'
-            django-version: 'main'
           - python-version: '3.7'
             django-version: 'main'
           - python-version: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         django-version: ['main', '2.0', '2.1', '2.2', '3.0', '3.1', '3.2', '4.0']
         exclude:
           - python-version: '3.8'
@@ -25,24 +25,11 @@ jobs:
           - python-version: '3.9'
             django-version: '2.1'
 
-          - python-version: '3.5'
-            django-version: '3.0'
-
-          - python-version: '3.5'
-            django-version: '3.1'
-
-          - python-version: '3.5'
-            django-version: '3.2'
-
-          - python-version: '3.5'
-            django-version: '4.0'
           - python-version: '3.6'
             django-version: '4.0'
           - python-version: '3.7'
             django-version: '4.0'
 
-          - python-version: '3.5'
-            django-version: 'main'
           - python-version: '3.6'
             django-version: 'main'
           - python-version: '3.7'

--- a/allauth/socialaccount/providers/twitch/provider.py
+++ b/allauth/socialaccount/providers/twitch/provider.py
@@ -28,7 +28,6 @@ class TwitchProvider(OAuth2Provider):
     def extract_common_fields(self, data):
         return {
             "username": data.get("login"),
-            "display_name": data.get("display_name"),
             "email": data.get("email"),
         }
 

--- a/allauth/socialaccount/providers/twitch/provider.py
+++ b/allauth/socialaccount/providers/twitch/provider.py
@@ -28,7 +28,7 @@ class TwitchProvider(OAuth2Provider):
     def extract_common_fields(self, data):
         return {
             "username": data.get("login"),
-            "name": data.get("display_name"),
+            "display_name": data.get("display_name"),
             "email": data.get("email"),
         }
 

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,6 @@ METADATA = dict(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,6 @@ METADATA = dict(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 skip_install = True
 deps =
     Sphinx
-whitelist_externals = make
+allowlist_externals = make
 commands =
     make -C {toxinidir}/docs html
 
@@ -50,6 +50,7 @@ commands =
 
 [testenv:standardjs]
 skip_install = True
+allowlist_externals = /usr/bin/env
 commands =
     /usr/bin/env bash -c "mkdir -p {toxinidir}/node_modules"
     /usr/bin/env npm install standard --no-lockfile --no-progress --non-interactive --silent

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,5 @@
 [tox]
 envlist =
-    py{37}-django20
-    py{37}-django21
-    py{37,38,39}-django22
-    py{37,38,39}-django30
-    py{37,38,39}-django31
     py{37,38,39}-django32
     py{38,39}-django40
     py{39}-djangomain
@@ -17,11 +12,6 @@ setenv =
     PYTHONWARNINGS = all
 deps =
     coverage
-    django20: Django==2.0.*
-    django21: Django==2.1.*
-    django22: Django==2.2.*
-    django30: Django==3.0.*
-    django31: Django==3.1.*
     django32: Django==3.2.*
     django40: Django==4.0.*
     djangomain: git+https://github.com/django/django.git@main#egg=django
@@ -78,10 +68,5 @@ PYTHON_VER =
     3.9: py39
 DJANGO =
     main: djangomain
-    2.0: django20
-    2.1: django21
-    2.2: django22
-    3.0: django30
-    3.1: django31
     3.2: django32
     4.0: django40

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py{36,37}-django20
-    py{36,37}-django21
-    py{36,37,38,39}-django22
-    py{36,37,38,39}-django30
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
+    py{37}-django20
+    py{37}-django21
+    py{37,38,39}-django22
+    py{37,38,39}-django30
+    py{37,38,39}-django31
+    py{37,38,39}-django32
     py{38,39}-django40
     py{39}-djangomain
     docs
@@ -73,7 +73,6 @@ exclude = migrations
 
 [gh-actions:env]
 PYTHON_VER =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{35,36,37}-django20
-    py{35,36,37}-django21
-    py{35,36,37,38,39}-django22
+    py{36,37}-django20
+    py{36,37}-django21
+    py{36,37,38,39}-django22
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32
@@ -73,7 +73,6 @@ exclude = migrations
 
 [gh-actions:env]
 PYTHON_VER =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38


### PR DESCRIPTION
 ## Provider Specifics
Twitch returns a display_name field in the oauth exchange, but we cannot assume that the display name is a given, legal name of some sort. Assuming such, as extract_common_fields does here, results in the BaseProvider, when creating a sociallogin from the response, parsing the display name as a first name because the key was "name" 